### PR TITLE
`compileSdkVersion` is deprecated in favor of `compileSdk`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ apply plugin: 'com.android.application'
 android {
     namespace "pl.czak.minimal"
 
-    compileSdkVersion 34
+    compileSdk 34
 
     defaultConfig {
         targetSdk 34


### PR DESCRIPTION
According to a random blog post and IntelliJ IDEA, this is a change